### PR TITLE
revamp the coap API

### DIFF
--- a/examples/coap.rs
+++ b/examples/coap.rs
@@ -110,7 +110,7 @@ fn main() -> Result<(), Error> {
             mtx.add_option(coap::OptionNumber::UriPath, segment.as_bytes());
         }
     }
-    mtx.set_payload(
+    let mtx = mtx.set_payload(
         matches
             .value_of("payload")
             .map(|s| s.as_bytes())

--- a/panic-never/examples/coap.rs
+++ b/panic-never/examples/coap.rs
@@ -1,0 +1,46 @@
+#![feature(asm)]
+#![feature(maybe_uninit)]
+#![no_std]
+#![no_main]
+
+use core::mem::MaybeUninit;
+
+use cortex_m_rt::{entry, exception};
+use panic_never::force_eval;
+
+use jnet::coap;
+
+const LEN: usize = 128;
+static mut BUFFER: [u8; LEN] = [0; LEN];
+static mut MESSAGE: MaybeUninit<coap::Message<&'static mut [u8]>> = MaybeUninit::uninitialized();
+
+#[exception]
+unsafe fn SysTick() {
+    if let Ok(p) = coap::Message::parse(&mut BUFFER[..]) {
+        MESSAGE.set(p);
+    } else {
+        asm!("NOP" : : : : "volatile");
+    }
+}
+
+#[exception]
+unsafe fn SVCall() {
+    let m = MESSAGE.get_mut();
+
+    force_eval!(m.get_version());
+    force_eval!(m.get_type());
+    force_eval!(m.get_token_length());
+    force_eval!(m.get_code());
+    force_eval!(m.get_message_id());
+    force_eval!(m.token());
+    force_eval!(m.payload());
+    for opt in m.options() {
+        force_eval!(opt.number());
+        force_eval!(opt.value());
+    }
+}
+
+#[entry]
+fn main() -> ! {
+    loop {}
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,11 +76,11 @@
 //!     ip.set_destination(IP_DST);
 //!     ip.udp(|udp| {
 //!         udp.set_destination(coap::PORT);
-//!         udp.coap(0, |coap| {
+//!         udp.coap(0, |mut coap| {
 //!             coap.set_type(coap::Type::Confirmable);
 //!             coap.set_code(coap::Method::Put);
 //!             coap.add_option(coap::OptionNumber::UriPath, b"led");
-//!             coap.set_payload(b"on");
+//!             coap.set_payload(b"on")
 //!         })
 //!     });
 //! });

--- a/src/udp.rs
+++ b/src/udp.rs
@@ -7,7 +7,11 @@ use as_slice::{AsMutSlice, AsSlice};
 use byteorder::{ByteOrder, NetworkEndian as NE};
 use cast::{u16, usize};
 
-use crate::{coap, traits::UncheckedIndex, Resize};
+use crate::{
+    coap::{self, Unset},
+    traits::UncheckedIndex,
+    Resize,
+};
 
 /* Packet structure */
 const SOURCE: Range<usize> = 0..2;
@@ -175,12 +179,11 @@ where
     /// Fills the payload with a CoAP message
     pub fn coap<F>(&mut self, token_length: u8, f: F)
     where
-        F: FnOnce(&mut coap::Message<&mut [u8]>),
+        F: FnOnce(coap::Message<&mut [u8], Unset>) -> coap::Message<&mut [u8]>,
     {
         let len = {
-            let mut coap = coap::Message::new(self.payload_mut(), token_length);
-            f(&mut coap);
-            coap.len()
+            let m = coap::Message::new(self.payload_mut(), token_length);
+            f(m).len()
         };
         self.truncate(len);
     }


### PR DESCRIPTION
now it's not possible to invalidate the payload while constructing a new Message

this commit also removing panicking branches from the parser and getter methods